### PR TITLE
Add named lists

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -88,6 +88,22 @@ command! -buffer -nargs=1 Doline call qf#DoList(1, <q-args>)
 "   :Dofile %s/^/---
 command! -buffer -nargs=1 Dofile call qf#DoList(0, <q-args>)
 
+" save current loc/qf list and associate it with a given name or the
+" last used name
+command! -buffer -nargs=? -complete=customlist,qf#CompleteList SaveList call qf#SaveList(0, <q-args>)
+" like SaveList, but add to a potentially existing named list
+command! -buffer -nargs=? -complete=customlist,qf#CompleteList SaveListAdd call qf#SaveList(1, <q-args>)
+
+" replace loc/qf list with named lists
+command! -buffer -nargs=+ -complete=customlist,qf#CompleteList LoadList call qf#LoadList(0, <q-args>)
+" like LoadList but append instead of replace
+command! -buffer -nargs=+ -complete=customlist,qf#CompleteList LoadListAdd call qf#LoadList(1, <q-args>)
+
+" list currently saved lists
+command! -buffer ListLists call qf#ListLists()
+" remove given lists or all
+command! -buffer -nargs=* -bang -complete=customlist,qf#CompleteList RemoveList call qf#RemoveList(expand("<bang>") == "!" ? 1 : 0, <q-args>)
+
 " TODO: allow customization
 " jump to previous/next file grouping
 nnoremap <silent> <buffer> } :call qf#NextFile()<CR>

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -290,6 +290,25 @@ endfunction
 let s:named_lists = {}
 let s:last_saved_list = ''
 
+function qf#GetNamedListTitle()
+    " get the searched term from the window title
+    if w:quickfix_title =~ '^:set'
+        " if the title starts with ':set' the qf/loclist window was
+        " filled with an empty list - hence :setqflist() / :setloclist()
+        " in this case the title doesn't need to be parsed
+        return ''
+    elseif w:quickfix_title =~ '^Named List:'
+        let len = strlen('Named List:')
+    elseif w:quickfix_title =~ '^:helpgrep'
+        let len = strlen(':helpgrep')
+    else
+        let len = strlen(&grepprg)
+    endif
+
+    " +2 to cut off spaces
+    return w:quickfix_title[len + 2:]
+endfunction
+
 function qf#SaveList(add, name) abort
     if a:name != ''
         let curname = a:name
@@ -323,18 +342,23 @@ function qf#SaveList(add, name) abort
         unlet entry.valid
     endfor
 
+    let title = qf#GetNamedListTitle()
+
     if a:add
-        let s:named_lists[curname] += curlist
+        let s:named_lists[curname].list += curlist
+        let s:named_lists[curname].title .= ' ' . title
     else
-        let s:named_lists[curname] = curlist
+        let s:named_lists[curname] = {}
+        let s:named_lists[curname].list = curlist
+        let s:named_lists[curname].title = title
     endif
 endfunction
 
-function qf#LoadList(add, ...)
-    if empty(a:000)
+function qf#LoadList(add, names)
+    if empty(a:names)
         let names = [ s:last_saved_list ]
     else
-        let names = a:000
+        let names = a:names
     endif
 
     if !a:add
@@ -345,12 +369,13 @@ function qf#LoadList(add, ...)
         endif
     endif
 
-    for name in names
+    for name in split(names, ' ')
         if has_key(s:named_lists, name)
+            let w:quickfix_title = 'Named List: ' . qf#GetNamedListTitle() . s:named_lists[name].title
             if get(b:, 'isLoc', 0)
-                call setloclist(0, s:named_lists[name], 'a')
+                call setloclist(0, s:named_lists[name].list, 'a')
             else
-                call setqflist(s:named_lists[name], 'a')
+                call setqflist(s:named_lists[name].list, 'a')
             endif
         else
             echomsg 'No list named "' . name . '" saved'
@@ -359,8 +384,19 @@ function qf#LoadList(add, ...)
 endfunction
 
 function qf#ListLists()
+    if len(s:named_lists) == 0
+        return
+    endif
+
+    let name_lengths = []
     for name in keys(s:named_lists)
-        echo name
+        call add(name_lengths, strlen(name))
+    endfor
+    let max_length = max(name_lengths) + 1
+
+    echo printf('%' . max_length . 'S %s', 'Name', 'Titles')
+    for name in keys(s:named_lists)
+        echo printf('%' . max_length . 'S %s', name, s:named_lists[name].title)
     endfor
 endfunction
 

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -287,4 +287,103 @@ function qf#FunctionName(argument)
     endif
 endfunction
 
+let s:named_lists = {}
+let s:last_saved_list = ''
+
+function qf#SaveList(add, name) abort
+    if a:name != ''
+        let curname = a:name
+        let s:last_saved_list = curname
+    else
+        if s:last_saved_list == ''
+            echomsg 'No last saved list'
+            return
+        endif
+        let curname = s:last_saved_list
+    endif
+
+    if get(b:, 'isLoc', 0)
+        let curlist = getloclist(0)
+    else
+        let curlist = getqflist()
+    endif
+
+    if empty(curlist)
+        " fail silently on empty lists
+        return
+    endif
+
+    for entry in curlist
+        " grab the correct filename for setqflist() in case the
+        " corresponding buffer is being closed in the meantime
+        let entry.filename = bufname(entry.bufnr)
+        unlet entry.bufnr
+
+        " unlet valid, not recognized by setqflist()
+        unlet entry.valid
+    endfor
+
+    if a:add
+        let s:named_lists[curname] += curlist
+    else
+        let s:named_lists[curname] = curlist
+    endif
+endfunction
+
+function qf#LoadList(add, ...)
+    if empty(a:000)
+        let names = [ s:last_saved_list ]
+    else
+        let names = a:000
+    endif
+
+    if !a:add
+        if get(b:, 'isLoc', 0)
+            call setloclist(0, [])
+        else
+            call setqflist([])
+        endif
+    endif
+
+    for name in names
+        if has_key(s:named_lists, name)
+            if get(b:, 'isLoc', 0)
+                call setloclist(0, s:named_lists[name], 'a')
+            else
+                call setqflist(s:named_lists[name], 'a')
+            endif
+        else
+            echomsg 'No list named "' . name . '" saved'
+        endif
+    endfor
+endfunction
+
+function qf#ListLists()
+    for name in keys(s:named_lists)
+        echo name
+    endfor
+endfunction
+
+function qf#RemoveList(bang, ...)
+    if a:bang
+        let s:named_lists = {}
+    else
+        for name in a:000
+            call remove(s:named_lists, name)
+        endfor
+    endif
+endfunction
+
+function qf#CompleteList(ArgLead, CmdLine, CursorPos)
+    let completions = []
+
+    for name in keys(s:named_lists)
+        if name =~ a:ArgLead
+            call add(completions, name)
+        endif
+    endfor
+
+    return completions
+endfunction
+
 let &cpo = s:save_cpo

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -381,6 +381,12 @@ function qf#LoadList(add, names)
             echomsg 'No list named "' . name . '" saved'
         endif
     endfor
+
+    set modifiable
+    %sort
+    %!uniq
+    set nomodifiable
+    set nomodified
 endfunction
 
 function qf#ListLists()

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -214,6 +214,55 @@ is focused:
 
         :Dofile norm @q
 <
+*:SaveList*
+
+    Saves the current quickfix/location list and associates it
+    with a given name. If no name is supplied the last saved
+    list is used.
+
+    Example: >
+
+        :SaveList curlist
+<
+*:SaveListAdd*
+
+    Like |:SaveList|, but adds to an existing named list.
+
+    Example: >
+
+        :SaveListAdd curlist
+<
+*:LoadList*
+
+    Replaces the current quickfix/location list with one or more saved named
+    lists. If no name is supplied, the last saved list is used.
+
+    Example: >
+
+        :LoadList curlist
+<
+*:LoadListAdd*
+
+    Like |:LoadList|, but adds to an existing quickfix/location list.
+
+    Example: >
+
+        :LoadListAdd curlist
+<
+*:ListLists*
+
+    Lists all currently saved lists.
+
+    Example: >
+
+        :ListLists
+        curlist
+        another_list
+<
+*:RemoveList*
+
+    Removes given lists. With a bang all saved lists are removed.
+
 NOTE: In most cases it is possible to only type a few characters to
 disembiguate commands. Assuming you don't already have custom commands with
 clashing names, you can shorten the commands above to:
@@ -225,7 +274,42 @@ clashing names, you can shorten the commands above to:
     |:Dofile| ..................................... :Dof
 
 ==============================================================================
- 5. ACKNOWLEGEMENTS                                       *qf-acknowledgements*
+ 5. NAMED LISTS                                                *qf-named-lists*
+
+While vim remembers the last ten quickfix/location lists and provides commands
+to switch between them (|:colder|, |:lolder|, |:cnewer|, |:lnewer|), this doesn't
+necessarily suffice and doesn't include changes made with |:Reject| et al.
+
+So vim-qf provides commands to save quickfix and location lists for later reuse
+and concatenation. This can be handy to compose a long list of matches to act
+on with |:cdo|, |:ldo| and family.
+
+These named lists share the same space, so a location list can be converted to
+a quickfix list: >
+    :SaveList current_loclist
+    :cwindow
+    :LoadList current_loclist
+<
+Concatenating multiple location lists to use as a quickfix list: >
+    :SaveListAdd current_loclist
+< in each location list you want to use, then >
+    :cwindow
+    :LoadList current_loclist
+<
+Composing a list of files to attach a license to: >
+    :grep _GNU_SOURCE
+    :Reject false_positives
+    :SaveListAdd floss_files
+    :grep POSIX_ME_HARDER
+    :Reject false_positives
+    :SaveListAdd floss_files
+< and so on >
+    :cwindow
+    :LoadList floss_files
+    :cdo 0r /path/to/license
+<
+==============================================================================
+ 6. ACKNOWLEGEMENTS                                       *qf-acknowledgements*
 
 The "Ack.vim-inspired mappings" are adapted from Ack.vim:
 
@@ -249,13 +333,14 @@ a proper plugin come from Barry Arthur's Area 41 plugin:
     - https://github.com/dahu/Area-41
 
 ==============================================================================
- 6. TODO                                                              *qf-todo*
+ 7. TODO                                                              *qf-todo*
 
     - Export more options?
     - Add a gifcast to the README?
+    - Add titles to saved lists, e.g. to display in :ListLists?
 
 ==============================================================================
- 7. DONE                                                              *qf-done*
+ 8. DONE                                                              *qf-done*
 
     - Use <Plug> mappings.
     - Add proper attribution for a few features.

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -253,11 +253,23 @@ is focused:
 
     Lists all currently saved lists.
 
+    The name is the user-given name and the title is parsed from the command
+    that generates the saved list.
+
     Example: >
 
+        :grep zsh
+        :SaveList shell
+        :grep bash
+        :SaveListAdd shell
+        :grep setopt
+        :SaveList options
+        :grep shopt
+        :SaveListAdd options
         :ListLists
-        curlist
-        another_list
+            Name Title
+           shell zsh bash
+         options setopt shopt
 <
 *:RemoveList*
 

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -237,6 +237,9 @@ is focused:
     Replaces the current quickfix/location list with one or more saved named
     lists. If no name is supplied, the last saved list is used.
 
+    The list is being sorted and uniq'd, so the result is as if |:grep| with
+    an appropriate expression would have been run.
+
     Example: >
 
         :LoadList curlist


### PR DESCRIPTION
I'm contend with it so far. A possibly neat thing to add would be to add
associated titles (like what you already did for the statusline) to the
named lists. Currently the named lists are just a dict:

```vim
let named_lists = {
            'some_list': [{entry}, {entry}, ...],
            'other_list': [{entry}, {entry}, ...],
        }
```

And `:ListLists` only displays their names.

With associated titles it could look like this:

```vim
let named_lists = {
            'some_list': {
                title: 'first_grep second_grep'
                list: [{entry}, {entry}, ...],
            },
            'other_list': {
                title: 'third_grep fourth_grep',
                list: [{entry}, {entry}, ...],
            },
        }
```

And `:ListLists` could display it as such:

```
:ListLists
some_list       first_grep second_grep
other_list      third_grep fourth_grep
```
