### PR TITLE
Add options to open qf/loclist windows at the bottom

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -34,10 +34,6 @@ if exists("g:qf_statusline")
     execute "setlocal statusline=" . g:qf_statusline.before . "%{qf#SetStatusline()}" . g:qf_statusline.after
 endif
 
-" force the quickfix window to be opened at the bottom
-" of the screen and take the full width
-wincmd J
-
 " inspired by Ack.vim
 if exists("g:qf_mapping_ack_style")
     " open entry in a new horizontal window

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -89,6 +89,8 @@ Available options:
 
     qf_mapping_ack_style .......................... |qf_mapping_ack_style|
     qf_statusline ................................. |qf_statusline|
+    qf_window_bottom .............................. |qf_window_bottom|
+    qf_loclist_window_bottom ...................... |qf_loclist_window_bottom|
 
 ------------------------------------------------------------------------------
                                                                   *QfCprevious*
@@ -151,6 +153,28 @@ Ack.vim-inspired mappings available only in the quickfix window:
 Add the line below to your vimrc to enable that feature: >
 
     let g:qf_mapping_ack_style = 1
+<
+------------------------------------------------------------------------------
+                                                            *'qf_window_bottom'*
+Value: numeric                                                               ~
+Default: 1                                                                   ~
+
+Open quickfix window at the bottom.
+
+Add the line below to your vimrc to disable that feature: >
+
+    let g:qf_window_bottom = 0
+<
+------------------------------------------------------------------------------
+                                                    *'qf_loclist_window_bottom'*
+Value: numeric                                                               ~
+Default: 1                                                                   ~
+
+Open location list windows at the bottom.
+
+Add the line below to your vimrc to disable that feature: >
+
+    let g:qf_loclist_window_bottom = 0
 <
 ------------------------------------------------------------------------------
                                                                *'qf_statusline'*

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -33,8 +33,8 @@ nnoremap <expr> <silent> <Plug>QfSwitch &filetype == "qf" ? "<C-w>p" : "<C-w>b"
 " :lvimgrep and friends if there are valid locations/errors
 augroup qf
     autocmd!
-    autocmd QuickFixCmdPost [^l]* cwindow
-    autocmd QuickFixCmdPost l*    lwindow
+    autocmd QuickFixCmdPost [^l]* cwindow | if get(g:, 'qf_window_bottom', 1) | wincmd J | endif
+    autocmd QuickFixCmdPost l*    lwindow | if get(g:, 'qf_loclist_window_bottom', 1) | wincmd J | endif
 augroup END
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
    Add 'qf_window_bottom' and 'qf_loclist_window_bottom' to allow moving qf
    and location list windows separately to the bottom, instead of moving
    both down.

    The default is 1 for consistency.

Personally I think having the location list window directly below the
window it refers to is handy and I'd like to keep it that way - having
the qf list on the bottom however is quite good.
