### PR TITLE
Automatically close loclist windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * perform commands on each file in the list,
 * open the location/quickfix window automatically after `:make`, `:grep`, `:lvimgrep` and friends if there are valid locations/errors
 * quit Vim if the last window is a location/quickfix window
+* close location window automatically when quitting parent window
 
 ## Installation
 

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -35,6 +35,9 @@ augroup qf
     " :lvimgrep and friends if there are valid locations/errors
     autocmd QuickFixCmdPost [^l]* cwindow | if get(g:, 'qf_window_bottom', 1) | wincmd J | endif
     autocmd QuickFixCmdPost l*    lwindow | if get(g:, 'qf_loclist_window_bottom', 1) | wincmd J | endif
+
+    " automatically close corresponding loclist when quitting a window
+    autocmd qf QuitPre * if &buftype != 'quickfix' | silent! lclose | endif
 augroup END
 
 let &cpo = s:save_cpo

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -29,10 +29,10 @@ nnoremap <silent> <Plug>QfLnext     :call qf#WrapCommand('up', 'l')<CR>
 " jump to and from the location/quickfix window
 nnoremap <expr> <silent> <Plug>QfSwitch &filetype == "qf" ? "<C-w>p" : "<C-w>b"
 
-" automatically open the location/quickfix window after :make, :grep,
-" :lvimgrep and friends if there are valid locations/errors
 augroup qf
     autocmd!
+    " automatically open the location/quickfix window after :make, :grep,
+    " :lvimgrep and friends if there are valid locations/errors
     autocmd QuickFixCmdPost [^l]* cwindow | if get(g:, 'qf_window_bottom', 1) | wincmd J | endif
     autocmd QuickFixCmdPost l*    lwindow | if get(g:, 'qf_loclist_window_bottom', 1) | wincmd J | endif
 augroup END


### PR DESCRIPTION
Uses the `QuitPre` autocmd event to call `:lclose` when quitting a window, closing the associated loclist (if any) along with it.