### PR TITLE
Auto-open qflist/loclist windows with less height where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - optional mapping for jumping to and from the location/quickfix window,
 - optional mappings for toggling location/quickfix windows
 - optionally open the location/quickfix window automatically after `:make`, `:grep`, `:lvimgrep` and friends if there are valid locations/errors
+- set height of location/quickfix windows automatically to the number of list items if less than the default height (10)
 - quit Vim if the last window is a location/quickfix window
 - close the location window automatically when quitting parent window
 

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -517,14 +517,14 @@ endfunction
 " open the quickfix window if there are valid errors
 function qf#OpenQuickfix()
     if get(g:, 'qf_auto_open_quickfix', 1)
-        cwindow
+        exe min([ 10, len(getqflist()) ]) 'cwindow'
     endif
 endfunction
 
 " open a location window if there are valid locations
 function qf#OpenLoclist()
     if get(g:, 'qf_auto_open_loclist', 1)
-        lwindow
+        exe min([ 10, len(getloclist(0)) ]) 'lwindow'
     endif
 endfunction
 

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -31,6 +31,8 @@ These "global" features are available from any window:
     - optional mappings for toggling location/quickfix windows
     - optionally open the location/quickfix window automatically after |:make|,
       |:grep|, |:lvimgrep| and friends if there are valid locations/errors
+    - set height of location/quickfix windows automatically to the number of
+      list items if less than the default height (10)
     - quit Vim if the last window is a location/quickfix window
     - close the location window automatically when quitting parent window
 


### PR DESCRIPTION
When automatically opening the quickfix/location lists, and there are fewer list items than the default height of the list window (10), these changes open the list window just high enough to show all the list items.