### PR TITLE
Add .gitignore for doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
If used via git submodules, having a dirty submodule because of tags creation is not nice.