### PR TITLE
 Only enable auto-close if vim has QuitPre autocmd

### DIFF
--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -62,7 +62,7 @@ augroup qf
     autocmd VimEnter        *     call qf#OpenQuickfix()
 
     " automatically close corresponding loclist when quitting a window
-    if v:version > 703 || (v:version == 703 && has('patch544'))
+    if exists('##QuitPre')
         autocmd QuitPre * if &filetype != 'qf' | silent! lclose | endif
     endif
 augroup END

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -62,7 +62,9 @@ augroup qf
     autocmd VimEnter        *     call qf#OpenQuickfix()
 
     " automatically close corresponding loclist when quitting a window
-    autocmd QuitPre * if &filetype != 'qf' | silent! lclose | endif
+    if v:version > 703 || (v:version == 703 && has('patch544'))
+        autocmd QuitPre * if &filetype != 'qf' | silent! lclose | endif
+    endif
 augroup END
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Synced my vim config to another machine today and got this when starting vim:

```
Error detected while processing /Users/avery/.vim/bundle/vim-qf/plugin/qf.vim:
line   65:
E216: No such group or event: QuitPre * if &filetype != 'qf' | silent! lclose | endif
Press ENTER or type command to continue
```

I guess my version of vim is too old to have QuitPre but can't really update on that machine.  I'm no vimscript expert so I found a fix to [this issue for syntastic](https://github.com/vim-syntastic/syntastic/issues/628) and tried to apply it here.  It's been working for me so submitting a PR in case it helps anyone else.