### PR TITLE
Option to enable/disable saving of current window view when toggling qf window

### DIFF
--- a/autoload/qf/toggle.vim
+++ b/autoload/qf/toggle.vim
@@ -22,7 +22,9 @@ set cpo&vim
 " toggles the quickfix window
 function! qf#toggle#ToggleQfWindow(stay) abort
     " save the view if the current window is not a quickfix window
-    let winview = qf#IsQfWindow(winnr()) ? {} : winsaveview()
+    if g:qf_save_win_view
+        let winview = qf#IsQfWindow(winnr()) ? {} : winsaveview()
+    endif
 
     " if one of the windows is a quickfix window close it and return
     if qf#IsQfWindowOpen()
@@ -48,7 +50,9 @@ endfunction
 " or whatever location window has the focus
 function! qf#toggle#ToggleLocWindow(stay) abort
     " save the view if the current window is not a location window
-    let winview = qf#IsLocWindow(winnr()) ? {} : winsaveview()
+    if g:qf_save_win_view
+        let winview = qf#IsLocWindow(winnr()) ? {} : winsaveview()
+    endif
 
     if qf#IsLocWindowOpen(0)
         lclose

--- a/autoload/qf/toggle.vim
+++ b/autoload/qf/toggle.vim
@@ -22,8 +22,10 @@ set cpo&vim
 " toggles the quickfix window
 function! qf#toggle#ToggleQfWindow(stay) abort
     " save the view if the current window is not a quickfix window
-    if g:qf_save_win_view
-        let winview = qf#IsQfWindow(winnr()) ? {} : winsaveview()
+    if get(g:, 'qf_save_win_view', 1)  && !qf#IsQfWindow(winnr())
+        let winview = winsaveview()
+    else
+        let winview = {}
     endif
 
     " if one of the windows is a quickfix window close it and return
@@ -50,8 +52,10 @@ endfunction
 " or whatever location window has the focus
 function! qf#toggle#ToggleLocWindow(stay) abort
     " save the view if the current window is not a location window
-    if g:qf_save_win_view
-        let winview = qf#IsLocWindow(winnr()) ? {} : winsaveview()
+    if get(g:, 'qf_save_win_view', 1) && !qf#IsLocWindow(winnr())
+        let winview = winsaveview()
+    else
+        let winview = {}
     endif
 
     if qf#IsLocWindowOpen(0)

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -111,6 +111,7 @@ Options:
     g:qf_max_height ............................ |'g:qf_max_height'|
     g:qf_auto_quit ............................. |'g:qf_auto_quit'|
     g:qf_bufname_or_text ....................... |'g:qf_bufname_or_text'|
+    g:qf_save_win_view ......................... |'g:qf_save_win_view'|
 
 ------------------------------------------------------------------------------
                                                          *<Plug>qf_qf_previous*
@@ -332,6 +333,17 @@ Determines what fields to filter on. Possible values are:
 Add the line below to your vimrc to change the default value:
 >
     let g:qf_bufname_or_text = 1
+<
+------------------------------------------------------------------------------
+                                                       *'g:qf_save_win_view'*
+Value: numeric                                                               ~
+Default: 1                                                                   ~
+
+Save the view of the current window when toggling location/quickfix window.
+
+Add the line below to your vimrc to change the default value:
+>
+    let g:qf_save_win_view = 0
 <
 ==============================================================================
  4. USAGE                                                            *qf-usage*


### PR DESCRIPTION
First off, great plugin! 

This PR adds an option (`g:qf_save_win_view`) that allows the user to disable something that the plugin does already by default: save the current window view when toggling the quickfix window.

When opening or closing the quickfix window, I would prefer behavior identical to the default behavior that occurs when any other window is opened or closed, especially as it relates to the way that vim scrolls the existing buffer to make room for the new window. Vim tries to keep the line that the cursor was at the same percentage through the window. I find this reasonable, and would, therefore, be a user that sets `g:qf_save_win_view` to 0 instead of the default value of 1.

Regards,
Asheq