### PR TITLE
Add default g:qf_nowrap to match documentation

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -23,7 +23,7 @@ let b:undo_ftplugin = "setl fo< com< ofu<"
 
 " text wrapping is pretty much useless in the quickfix window
 " but some users may still want it
-execute get(g:, "qf_nowrap") ? "setlocal nowrap" : "setlocal wrap"
+execute get(g:, "qf_nowrap", 1) ? "setlocal nowrap" : "setlocal wrap"
 
 " relative line numbers don't make much sense either
 " but absolute numbers definitely do


### PR DESCRIPTION
The new g:qf_nowrap variable doesn't set a default value, so when it
isn't set by the user it defaults to 0, which doesn't match the
documentation and means that updating to a newer version of vim-qf
introduces a change in behaviour.