### PR TITLE
Fix mapping delays: Use parentheses for mappings

### DIFF
--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -86,15 +86,15 @@ on Windows... >
 
 Global mappings:
 
-    <Plug>qf_qf_previous ....................... |<Plug>qf_qf_previous|
-    <Plug>qf_qf_next ........................... |<Plug>qf_qf_next|
-    <Plug>qf_loc_previous ...................... |<Plug>qf_loc_previous|
-    <Plug>qf_loc_next .......................... |<Plug>qf_loc_next|
-    <Plug>qf_qf_switch ......................... |<Plug>qf_qf_switch|
-    <Plug>qf_qf_toggle ......................... |<Plug>qf_qf_toggle|
-    <Plug>qf_qf_stay_toggle .................... |<Plug>qf_qf_stay_toggle|
-    <Plug>qf_loc_toggle ........................ |<Plug>qf_loc_toggle|
-    <Plug>qf_loc_stay_toggle ................... |<Plug>qf_loc_stay_toggle|
+    <Plug>(qf_qf_previous) ..................... |<Plug>(qf_qf_previous)|
+    <Plug>(qf_qf_next) ......................... |<Plug>(qf_qf_next)|
+    <Plug>(qf_loc_previous) .................... |<Plug>(qf_loc_previous)|
+    <Plug>(qf_loc_next) ........................ |<Plug>(qf_loc_next)|
+    <Plug>(qf_qf_switch) ....................... |<Plug>(qf_qf_switch)|
+    <Plug>(qf_qf_toggle) ....................... |<Plug>(qf_qf_toggle)|
+    <Plug>(qf_qf_toggle_stay) .................. |<Plug>(qf_qf_toggle_stay)|
+    <Plug>(qf_loc_toggle) ...................... |<Plug>(qf_loc_toggle)|
+    <Plug>(qf_loc_toggle_stay) ................. |<Plug>(qf_loc_toggle_stay)|
 
 Local mappings:
 
@@ -117,8 +117,8 @@ Options:
     g:qf_nowrap ................................ |'g:qf_nowrap'|
 
 ------------------------------------------------------------------------------
-                                                         *<Plug>qf_qf_previous*
-                                                             *<Plug>qf_qf_next*
+                                                       *<Plug>(qf_qf_previous)*
+                                                           *<Plug>(qf_qf_next)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -126,12 +126,12 @@ Go up and down the quickfix list and wrap around.
 
 Example: >
 
-    nmap <Home> <Plug>qf_qf_previous
-    nmap <End>  <Plug>qf_qf_next
+    nmap <Home> <Plug>(qf_qf_previous)
+    nmap <End>  <Plug>(qf_qf_next)
 <
 ------------------------------------------------------------------------------
-                                                        *<Plug>qf_loc_previous*
-                                                            *<Plug>qf_loc_next*
+                                                      *<Plug>(qf_loc_previous)*
+                                                          *<Plug>(qf_loc_next)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -139,11 +139,11 @@ Go up and down the current location list and wrap around.
 
 Example: >
 
-    nmap <C-Home> <Plug>qf_loc_previous
-    nmap <C-End>  <Plug>qf_loc_next
+    nmap <C-Home> <Plug>(qf_loc_previous)
+    nmap <C-End>  <Plug>(qf_loc_next)
 <
 ------------------------------------------------------------------------------
-                                                           *<Plug>qf_qf_switch*
+                                                         *<Plug>(qf_qf_switch)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -151,10 +151,10 @@ Jump to and from location/quickfix windows.
 
 Example: >
 
-    nmap ç <Plug>qf_qf_switch
+    nmap ç <Plug>(qf_qf_switch)
 <
 ------------------------------------------------------------------------------
-                                                           *<Plug>qf_qf_toggle*
+                                                         *<Plug>(qf_qf_toggle)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -163,10 +163,10 @@ Uses |:cwindow| and |:cclose| under the hood.
 
 Example: >
 
-    nmap <F5> <Plug>qf_qf_toggle
+    nmap <F5> <Plug>(qf_qf_toggle)
 <
 ------------------------------------------------------------------------------
-                                                      *<Plug>qf_qf_stay_toggle*
+                                                    *<Plug>(qf_qf_toggle_stay)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -175,10 +175,10 @@ Uses |:cwindow| and |:cclose| under the hood.
 
 Example: >
 
-    nmap <F5> <Plug>qf_qf_stay_toggle
+    nmap <F5> <Plug>(qf_qf_toggle_stay)
 <
 ------------------------------------------------------------------------------
-                                                          *<Plug>qf_loc_toggle*
+                                                        *<Plug>(qf_loc_toggle)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -187,10 +187,10 @@ Uses |:lwindow| and |:lclose| under the hood.
 
 Example: >
 
-    nmap <F6> <Plug>qf_loc_toggle
+    nmap <F6> <Plug>(qf_loc_toggle)
 <
 ------------------------------------------------------------------------------
-                                                     *<Plug>qf_loc_stay_toggle*
+                                                   *<Plug>(qf_loc_toggle_stay)*
 Scope: global                                                                ~
 Default: none                                                                ~
 
@@ -200,7 +200,7 @@ Uses |:lwindow| and |:lclose| under the hood.
 
 Example: >
 
-    nmap <F6> <Plug>qf_loc_stay_toggle
+    nmap <F6> <Plug>(qf_loc_toggle_stay)
 <
 ------------------------------------------------------------------------------
                                                                *QfPreviousFile*

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -25,32 +25,32 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " Kept for backward compatibility
-nmap <silent>        <Plug>QfCprevious <Plug>qf_qf_previous
-nmap <silent>        <Plug>QfCnext     <Plug>qf_qf_next
-nmap <silent>        <Plug>QfLprevious <Plug>qf_loc_previous
-nmap <silent>        <Plug>QfLnext     <Plug>qf_loc_next
-nmap <silent>        <Plug>QfCtoggle   <Plug>qf_qf_toggle
-nmap <silent>        <Plug>QfLtoggle   <Plug>qf_loc_toggle
+nmap <silent>        <Plug>QfCprevious <Plug>(qf_qf_previous)
+nmap <silent>        <Plug>QfCnext     <Plug>(qf_qf_next)
+nmap <silent>        <Plug>QfLprevious <Plug>(qf_loc_previous)
+nmap <silent>        <Plug>QfLnext     <Plug>(qf_loc_next)
+nmap <silent>        <Plug>QfCtoggle   <Plug>(qf_qf_toggle)
+nmap <silent>        <Plug>QfLtoggle   <Plug>(qf_loc_toggle)
 nmap <silent> <expr> <Plug>QfSwitch    &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
 
 " Go up and down quickfix list
-nnoremap <silent>        <Plug>qf_qf_previous     :<C-u> call qf#wrap#WrapCommand('up', 'c')<CR>
-nnoremap <silent>        <Plug>qf_qf_next         :<C-u> call qf#wrap#WrapCommand('down', 'c')<CR>
+nnoremap <silent>        <Plug>(qf_qf_previous)     :<C-u> call qf#wrap#WrapCommand('up', 'c')<CR>
+nnoremap <silent>        <Plug>(qf_qf_next)         :<C-u> call qf#wrap#WrapCommand('down', 'c')<CR>
 
 " Go up and down location list
-nnoremap <silent>        <Plug>qf_loc_previous    :<C-u> call qf#wrap#WrapCommand('up', 'l')<CR>
-nnoremap <silent>        <Plug>qf_loc_next        :<C-u> call qf#wrap#WrapCommand('down', 'l')<CR>
+nnoremap <silent>        <Plug>(qf_loc_previous)    :<C-u> call qf#wrap#WrapCommand('up', 'l')<CR>
+nnoremap <silent>        <Plug>(qf_loc_next)        :<C-u> call qf#wrap#WrapCommand('down', 'l')<CR>
 
 " Toggle quickfix list
-nnoremap <silent>        <Plug>qf_qf_toggle       :<C-u> call qf#toggle#ToggleQfWindow(0)<CR>
-nnoremap <silent>        <Plug>qf_qf_stay_toggle  :<C-u> call qf#toggle#ToggleQfWindow(1)<CR>
+nnoremap <silent>        <Plug>(qf_qf_toggle)       :<C-u> call qf#toggle#ToggleQfWindow(0)<CR>
+nnoremap <silent>        <Plug>(qf_qf_toggle_stay)  :<C-u> call qf#toggle#ToggleQfWindow(1)<CR>
 
 " Toggle location list
-nnoremap <silent>        <Plug>qf_loc_toggle      :<C-u> call qf#toggle#ToggleLocWindow(0)<CR>
-nnoremap <silent>        <Plug>qf_loc_stay_toggle :<C-u> call qf#toggle#ToggleLocWindow(1)<CR>
+nnoremap <silent>        <Plug>(qf_loc_toggle)      :<C-u> call qf#toggle#ToggleLocWindow(0)<CR>
+nnoremap <silent>        <Plug>(qf_loc_toggle_stay) :<C-u> call qf#toggle#ToggleLocWindow(1)<CR>
 
 " Jump to and from list
-nnoremap <silent> <expr> <Plug>qf_qf_switch       &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
+nnoremap <silent> <expr> <Plug>(qf_qf_switch)       &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
 
 augroup qf
     autocmd!


### PR DESCRIPTION
Actually fixes #53

https://stackoverflow.com/questions/13688022/what-is-the-reason-to-parenthesize-plug-map-names

This reverts commit c2596df2be746ff3393d9d97e2ec986d4ea1a67c.