### PR TITLE
Add nested to autocmds

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -127,8 +127,8 @@ nnoremap <silent> <buffer> { :call qf#filegroup#PreviousFile()<CR>
 
 " quit Vim if the last window is a quickfix window
 
-autocmd qf BufEnter    <buffer> if get(g:, 'qf_auto_quit', 1) | if winnr('$') < 2 | q | endif | endif
-autocmd qf BufWinEnter <buffer> if get(g:, 'qf_auto_quit', 1) | call qf#filter#ReuseTitle() | endif
+autocmd qf BufEnter    nested <buffer> if get(g:, 'qf_auto_quit', 1) | if winnr('$') < 2 | q | endif | endif
+autocmd qf BufWinEnter nested <buffer> if get(g:, 'qf_auto_quit', 1) | call qf#filter#ReuseTitle() | endif
 
 " decide where to open the location/quickfix window
 if (b:qf_isLoc == 1 && get(g:, 'qf_loclist_window_bottom', 1))

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -59,11 +59,11 @@ augroup qf
     " :lvimgrep and friends if there are valid locations/errors
     autocmd QuickFixCmdPost [^l]* nested call qf#OpenQuickfix()
     autocmd QuickFixCmdPost    l* nested call qf#OpenLoclist()
-    autocmd VimEnter            * call qf#OpenQuickfix()
+    autocmd VimEnter            * nested call qf#OpenQuickfix()
 
     " automatically close corresponding loclist when quitting a window
     if exists('##QuitPre')
-        autocmd QuitPre * if &filetype != 'qf' | silent! lclose | endif
+        autocmd QuitPre * nested if &filetype != 'qf' | silent! lclose | endif
     endif
 augroup END
 

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -57,8 +57,8 @@ augroup qf
 
     " automatically open the location/quickfix window after :make, :grep,
     " :lvimgrep and friends if there are valid locations/errors
-    autocmd QuickFixCmdPost [^l]* call qf#OpenQuickfix()
-    autocmd QuickFixCmdPost    l* call qf#OpenLoclist()
+    autocmd QuickFixCmdPost [^l]* nested call qf#OpenQuickfix()
+    autocmd QuickFixCmdPost    l* nested call qf#OpenLoclist()
     autocmd VimEnter            * call qf#OpenQuickfix()
 
     " automatically close corresponding loclist when quitting a window


### PR DESCRIPTION
autcmds fired by vim-qf do not include the `nested` keyword. Plugins that rely on autocmds on e.g. entering a quickfix window won't work if the qf window is opened by vim-qf. 

This commits adds the nested keyword to the autocmds used in vim-qf