### PR TITLE
Update documentation and enable <nowait> and <plug> mappings

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -73,12 +73,16 @@ if exists("g:qf_mapping_ack_style")
 endif
 
 " Jump to previous/next file grouping
-if exists('g:qf_mapping_filegroup_previous')
-    execute "nnoremap <silent> <buffer> " . get(g:, 'qf_mapping_filegroup_previous', '{') . " :<C-u> call qf#filegroup#NextFile(0)<CR>"
+" Default to { and } for compatibility
+if !empty(get(g:, 'qf_mapping_filegroup_previous', 'default'))
+    execute "nmap <buffer> <nowait> " . get(g:, 'qf_mapping_filegroup_previous', '{') . " <Plug>(qf_fg_previous_file)"
 endif
-if exists('g:qf_mapping_filegroup_next')
-    execute "nnoremap <silent> <buffer> " . get(g:, 'qf_mapping_filegroup_next', '}') . " :<C-u> call qf#filegroup#NextFile(1)<CR>"
+if !empty(get(g:, 'qf_mapping_filegroup_next', 'default'))
+    execute "nmap <buffer> <nowait> " . get(g:, 'qf_mapping_filegroup_next', '}')     . " <plug>(qf_fg_next_file)"
 endif
+
+nnoremap <silent> <buffer> <Plug>(qf_fg_previous_file) :<C-u> call qf#filegroup#NextFile(0)<CR>
+nnoremap <silent> <buffer> <Plug>(qf_fg_next_file)     :<C-u> call qf#filegroup#NextFile(1)<CR>
 
 " filter the location/quickfix list
 " (kept for backward compatibility, use :Keep and :Reject instead)

--- a/autoload/qf/filegroup.vim
+++ b/autoload/qf/filegroup.vim
@@ -44,20 +44,6 @@ function! s:JumpFileChunk(down) abort
     call s:JumpToFirstItemOfFileChunk()
 endfunction
 
-function! s:ReuseMapping(down) abort
-    redir => l:nmaps
-    silent nmap
-    redir END
-
-    if a:down == 0
-        let lhs = split(filter(split(l:nmaps, "\n"), 'v:val =~ "<Plug>(qf_previous_file)$"')[0], '\s\+')[1]
-    else
-        let lhs = split(filter(split(l:nmaps, "\n"), 'v:val =~ "<Plug>(qf_next_file)$"')[0], '\s\+')[1]
-    endif
-
-    execute "normal! " . lhs
-endfunction
-
 function! qf#filegroup#NextFile(down) abort
     if exists("b:qf_isLoc")
         call s:JumpFileChunk(a:down)

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -87,35 +87,35 @@ on Windows... >
 
 Global mappings:
 
-    <Plug>(qf_qf_previous) ..................... |<Plug>(qf_qf_previous)|
-    <Plug>(qf_qf_next) ......................... |<Plug>(qf_qf_next)|
-    <Plug>(qf_loc_previous) .................... |<Plug>(qf_loc_previous)|
-    <Plug>(qf_loc_next) ........................ |<Plug>(qf_loc_next)|
-    <Plug>(qf_qf_switch) ....................... |<Plug>(qf_qf_switch)|
-    <Plug>(qf_qf_toggle) ....................... |<Plug>(qf_qf_toggle)|
-    <Plug>(qf_qf_toggle_stay) .................. |<Plug>(qf_qf_toggle_stay)|
-    <Plug>(qf_loc_toggle) ...................... |<Plug>(qf_loc_toggle)|
-    <Plug>(qf_loc_toggle_stay) ................. |<Plug>(qf_loc_toggle_stay)|
+    <Plug>(qf_qf_previous) ................ |<Plug>(qf_qf_previous)|
+    <Plug>(qf_qf_next) .................... |<Plug>(qf_qf_next)|
+    <Plug>(qf_loc_previous) ............... |<Plug>(qf_loc_previous)|
+    <Plug>(qf_loc_next) ................... |<Plug>(qf_loc_next)|
+    <Plug>(qf_qf_switch) .................. |<Plug>(qf_qf_switch)|
+    <Plug>(qf_qf_toggle) .................. |<Plug>(qf_qf_toggle)|
+    <Plug>(qf_qf_toggle_stay) ............. |<Plug>(qf_qf_toggle_stay)|
+    <Plug>(qf_loc_toggle) ................. |<Plug>(qf_loc_toggle)|
+    <Plug>(qf_loc_toggle_stay) ............ |<Plug>(qf_loc_toggle_stay)|
 
-Local mappings:
+Local Mappings:
 
-    <Plug>(qf_previous_file) ................... |<Plug>(qf_previous_file)|
-    <Plug>(qf_next_file) ....................... |<Plug(qf_next_file)|
+    g:qf_mapping_filegroup_previous........ |'g:qf_mapping_filegroup_previous'|
+    g:qf_mapping_filegroup_next ........... |'g:qf_mapping_filegroup_next'|
+    g:qf_mapping_ack_style ................ |'g:qf_mapping_ack_style'|
 
 Options:
 
-    g:qf_mapping_ack_style ..................... |'g:qf_mapping_ack_style'|
-    g:qf_statusline ............................ |'g:qf_statusline'|
-    g:qf_window_bottom ......................... |'g:qf_window_bottom'|
-    g:qf_loclist_window_bottom ................. |'g:qf_loclist_window_bottom'|
-    g:qf_auto_open_quickfix .................... |'g:qf_auto_open_quickfix'|
-    g:qf_auto_open_loclist ..................... |'g:qf_auto_open_loclist'|
-    g:qf_auto_resize ........................... |'g:qf_auto_resize'|
-    g:qf_max_height ............................ |'g:qf_max_height'|
-    g:qf_auto_quit ............................. |'g:qf_auto_quit'|
-    g:qf_bufname_or_text ....................... |'g:qf_bufname_or_text'|
-    g:qf_save_win_view ......................... |'g:qf_save_win_view'|
-    g:qf_nowrap ................................ |'g:qf_nowrap'|
+    g:qf_statusline ....................... |'g:qf_statusline'|
+    g:qf_window_bottom .................... |'g:qf_window_bottom'|
+    g:qf_loclist_window_bottom ............ |'g:qf_loclist_window_bottom'|
+    g:qf_auto_open_quickfix ............... |'g:qf_auto_open_quickfix'|
+    g:qf_auto_open_loclist ................ |'g:qf_auto_open_loclist'|
+    g:qf_auto_resize ...................... |'g:qf_auto_resize'|
+    g:qf_max_height ....................... |'g:qf_max_height'|
+    g:qf_auto_quit ........................ |'g:qf_auto_quit'|
+    g:qf_bufname_or_text .................. |'g:qf_bufname_or_text'|
+    g:qf_save_win_view .................... |'g:qf_save_win_view'|
+    g:qf_nowrap ........................... |'g:qf_nowrap'|
 
 ------------------------------------------------------------------------------
                                                        *<Plug>(qf_qf_previous)*
@@ -204,21 +204,29 @@ Example: >
     nmap <F6> <Plug>(qf_loc_toggle_stay)
 <
 ------------------------------------------------------------------------------
-                                                     *<Plug>(qf_previous_file)*
-                                                         *<Plug>(qf_next_file)*
+                                            *'g:qf_mapping_filegroup_previous'*
+                                                *'g:qf_mapping_filegroup_next'*
 Scope: local                                                                 ~
-Default: none                                                                ~
+Value: string                                                                ~
+Defaults: "{" , "}"                                                          ~
 
-In a location/quickfix window, jump to the next group of lines
-corresponding to a file.
+Jump to the previous/next group of lines corresponding to a file.
+Only available in location/quickfix windows
 
 Example: >
 
-    nmap { <Plug>(qf_previous_file)
-    nmap } <Plug>(qf_next_file)
+    let g:qf_mapping_filegroup_previous = "("
+    let g:qf_mapping_filegroup_next = ")"
+<
+
+This feature can be disabled by adding the following lines to your vimrc: >
+
+    let g:qf_mapping_filegroup_previous = ""
+    let g:qf_mapping_filegroup_next = ""
 <
 ------------------------------------------------------------------------------
                                                      *'g:qf_mapping_ack_style'*
+Scope: local                                                                 ~
 Value: numeric                                                               ~
 Default: 0                                                                   ~
 


### PR DESCRIPTION
This solution enables both customisation by global variable and <plug> mappings. I updated the documentation and enabled <nowait> on the mappings (see my comments in #74). The <plug> mappings are not documented; I'm not sure whether you wanted to document them. I also restored the default behaviour to `{` and `}` (instead of nothing) to prevent mappings unexpectedly breaking for everyone.