### PR TITLE
Fix LoadList inside loclist, and with multiple list names

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -111,9 +111,9 @@ command! -buffer -nargs=? -complete=customlist,qf#namedlist#CompleteList SaveLis
 command! -buffer -nargs=? -complete=customlist,qf#namedlist#CompleteList SaveListAdd call qf#namedlist#SaveList(1, <q-args>)
 
 " replace location/quickfix list with named lists
-command! -buffer -nargs=+ -complete=customlist,qf#namedlist#CompleteList LoadList    call qf#namedlist#LoadList(0, <q-args>)
+command! -buffer -nargs=? -complete=customlist,qf#namedlist#CompleteList LoadList    call qf#namedlist#LoadList(0, <q-args>)
 " like LoadList but append instead of replace
-command! -buffer -nargs=+ -complete=customlist,qf#namedlist#CompleteList LoadListAdd call qf#namedlist#LoadList(1, <q-args>)
+command! -buffer -nargs=? -complete=customlist,qf#namedlist#CompleteList LoadListAdd call qf#namedlist#LoadList(1, <q-args>)
 
 " list currently saved lists
 command! -buffer ListLists call qf#namedlist#ListLists()

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -84,22 +84,15 @@ function! qf#GetList()
 endfunction
 
 " sets location or qf list based in b:qf_isLoc to passed newlist
-function! qf#SetList(newlist, ...)
-    " generate partial
-    let Func = get(b:, 'qf_isLoc', 0)
-                \ ? function('setloclist', [0, a:newlist])
-                \ : function('setqflist', [a:newlist])
-
-    " get user-defined maximum height
+function! qf#SetList(newlist, opts)
     let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
 
-    " call partial with optional arguments
-    call call(Func, a:000)
-
-    if get(b:, 'qf_isLoc', 0)
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
-    else
+    if qf#IsQfWindow(winnr())
+        call setqflist(a:newlist, a:opts)
         execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+    else
+        call setloclist(0, a:newlist, a:opts)
+        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
     endif
 endfunction
 

--- a/autoload/qf/namedlist.vim
+++ b/autoload/qf/namedlist.vim
@@ -26,10 +26,8 @@ function! qf#namedlist#SaveList(add, name) abort
     if a:name == ''
         if s:last_saved_list == ''
             echomsg 'No last saved list'
-
             return
         endif
-
         let curname = s:last_saved_list
     else
         let curname           = a:name
@@ -61,24 +59,28 @@ function! qf#namedlist#SaveList(add, name) abort
 endfunction
 
 " loads the given named list
-function! qf#namedlist#LoadList(add, ...)
-    if empty(a:000)
-        let names = [ s:last_saved_list ]
+function! qf#namedlist#LoadList(add, names_arg)
+    if empty(a:names_arg)
+        let l:names = [ s:last_saved_list ]
     else
-        let names = a:000
+        let l:names = split(a:names_arg, " ")
     endif
 
-    if !a:add
-        call qf#SetList([])
-    endif
-
-    for name in names
+    let l:first = 1
+    for name in l:names
         if ! has_key(s:named_lists, name)
             echomsg 'No list named "' . name . '" saved'
             return
         endif
 
-        call qf#SetList(s:named_lists[name], 'a')
+        let l:action = 'a'
+        if l:first && !a:add
+            let l:action = 'r'
+        endif
+
+        let l:first = 0
+
+        call qf#SetList(s:named_lists[name], action)
     endfor
 endfunction
 


### PR DESCRIPTION
This makes LoadList work within both LocList and Quickfix.
Previously SetList was called with an empty list, which made the loc/quickfix list close, which in turn made the detection of loc/quickfix break.