### PR TITLE
Close qf window first before calling cwindow

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -97,9 +97,9 @@ function! qf#SetList(newlist, ...)
     call call(Func, a:000)
 
     if get(b:, 'qf_isLoc', 0)
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
     else
-        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
     endif
 endfunction
 
@@ -116,7 +116,7 @@ function! qf#OpenQuickfix()
     if get(g:, 'qf_auto_open_quickfix', 1)
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
-        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
     endif
 endfunction
 
@@ -125,7 +125,7 @@ function! qf#OpenLoclist()
     if get(g:, 'qf_auto_open_loclist', 1)
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
     endif
 endfunction
 

--- a/autoload/qf/filter.vim
+++ b/autoload/qf/filter.vim
@@ -55,7 +55,7 @@ function! s:SetList(pat, reject, strategy)
                 call setloclist(0, filter(getloclist(0), "v:val['text'] " . operator . " a:pat"), "r")
             endif
 
-            execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+            execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
         else
             " bufname && text
             if a:strategy == 0
@@ -72,7 +72,7 @@ function! s:SetList(pat, reject, strategy)
                 call setqflist(filter(getqflist(), "v:val['text'] " . operator . " a:pat"), "r")
             endif
 
-            execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+            execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
         endif
     endif
 endfunction
@@ -206,7 +206,7 @@ function! qf#filter#RestoreList()
 
             if len(lists) > 0
                 call setloclist(0, getwinvar(winnr("#"), "qf_location_lists")[0], "r")
-                execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+                execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
 
                 let w:quickfix_title = getwinvar(winnr("#"), "qf_location_titles")[0]
             else
@@ -216,7 +216,7 @@ function! qf#filter#RestoreList()
             if exists("g:qf_quickfix_lists")
                 if len(g:qf_quickfix_lists) > 0
                     call setqflist(g:qf_quickfix_lists[0], "r")
-                    execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+                    execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
 
                     let w:quickfix_title = g:qf_quickfix_titles[0]
                 else


### PR DESCRIPTION
With `g:qf_auto_resize = 0` Vim didn't move the focus to the quickfix (or
location list) window after a quickfix command was executed while the
quickfix window was already open. Similar to the case
`g:qf_auto_resize = 1`, we call `cclose` (or `lclose`) first, before calling
`cwindow` (or `lwindow`) to make sure focus is always moved to the
quickfix/location list window.
Fixes #79 