### PR TITLE
Use qf_max_height and qf_auto_resize values when toggling quickfix window

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -97,9 +97,9 @@ function! qf#SetList(newlist, ...)
     call call(Func, a:000)
 
     if get(b:, 'qf_isLoc', 0)
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
     else
-        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
     endif
 endfunction
 
@@ -116,7 +116,7 @@ function! qf#OpenQuickfix()
     if get(g:, 'qf_auto_open_quickfix', 1)
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
-        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
     endif
 endfunction
 
@@ -125,7 +125,7 @@ function! qf#OpenLoclist()
     if get(g:, 'qf_auto_open_loclist', 1)
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
     endif
 endfunction
 

--- a/autoload/qf/filter.vim
+++ b/autoload/qf/filter.vim
@@ -55,7 +55,7 @@ function! s:SetList(pat, reject, strategy)
                 call setloclist(0, filter(getloclist(0), "v:val['text'] " . operator . " a:pat"), "r")
             endif
 
-            execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+            execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
         else
             " bufname && text
             if a:strategy == 0
@@ -72,7 +72,7 @@ function! s:SetList(pat, reject, strategy)
                 call setqflist(filter(getqflist(), "v:val['text'] " . operator . " a:pat"), "r")
             endif
 
-            execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+            execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
         endif
     endif
 endfunction
@@ -206,7 +206,7 @@ function! qf#filter#RestoreList()
 
             if len(lists) > 0
                 call setloclist(0, getwinvar(winnr("#"), "qf_location_lists")[0], "r")
-                execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
+                execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lclose|lwindow'
 
                 let w:quickfix_title = getwinvar(winnr("#"), "qf_location_titles")[0]
             else
@@ -216,7 +216,7 @@ function! qf#filter#RestoreList()
             if exists("g:qf_quickfix_lists")
                 if len(g:qf_quickfix_lists) > 0
                     call setqflist(g:qf_quickfix_lists[0], "r")
-                    execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
+                    execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cclose|cwindow'
 
                     let w:quickfix_title = g:qf_quickfix_titles[0]
                 else

--- a/autoload/qf/toggle.vim
+++ b/autoload/qf/toggle.vim
@@ -28,6 +28,9 @@ function! qf#toggle#ToggleQfWindow(stay) abort
         let winview = {}
     endif
 
+    " get user-defined maximum height
+    let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
+
     " if one of the windows is a quickfix window close it and return
     if qf#IsQfWindowOpen()
         cclose
@@ -35,7 +38,7 @@ function! qf#toggle#ToggleQfWindow(stay) abort
             call winrestview(winview)
         endif
     else
-        cwindow
+        execute get(g:, 'qf_auto_resize', 1) ? min([ max_height, len(getqflist()) ]) . 'cwindow' : max_height . 'cwindow'
         if qf#IsQfWindowOpen()
             wincmd p
             if !empty(winview)
@@ -58,13 +61,16 @@ function! qf#toggle#ToggleLocWindow(stay) abort
         let winview = {}
     endif
 
+    " get user-defined maximum height
+    let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
+
     if qf#IsLocWindowOpen(0)
         lclose
         if !empty(winview)
             call winrestview(winview)
         endif
     else
-        lwindow
+        execute get(g:, 'qf_auto_resize', 1) ? min([ max_height, len(getloclist(0)) ]) . 'lwindow' : max_height . 'lwindow'
         if qf#IsLocWindowOpen(0)
             wincmd p
             if !empty(winview)


### PR DESCRIPTION
Respect user's `g:qf_max_height` and `g:qf_auto_resize` values when toggling the quickfix or location list windows.

Fixes #61.