### PR TITLE
Add list history navigation commands

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -154,6 +154,8 @@ let b:undo_ftplugin .= "| delcommand Filter"
             \ . "| delcommand RemoveList"
             \ . "| execute 'nunmap <buffer> }'"
             \ . "| execute 'nunmap <buffer> {'"
+            \ . "| execute 'nunmap <buffer> <Left>'"
+            \ . "| execute 'nunmap <buffer> <Right>'"
             \ . "| unlet! b:qf_isLoc"
 
 " decide where to open the location/quickfix window

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -127,6 +127,10 @@ command! -buffer ListLists call qf#namedlist#ListLists()
 " remove given lists or all
 command! -buffer -nargs=* -bang -complete=customlist,qf#namedlist#CompleteList RemoveList call qf#namedlist#RemoveList(expand("<bang>") == "!" ? 1 : 0, <q-args>)
 
+" navigate between older and newer lists
+nnoremap <silent> <buffer> <Left> :call qf#history#Older()<CR>
+nnoremap <silent> <buffer> <Right> :call qf#history#Newer()<CR>
+
 " TODO: allow customization
 " jump to previous/next file grouping
 nnoremap <silent> <buffer> } :call qf#filegroup#NextFile()<CR>

--- a/autoload/qf/history.vim
+++ b/autoload/qf/history.vim
@@ -1,0 +1,40 @@
+" vim-qf - Tame the quickfix window
+" Maintainer:	romainl <romainlafourcade@gmail.com>
+" Version:	0.2.0
+" License:	MIT
+" Location:	autoload/history.vim
+" Website:	https://github.com/romainl/vim-qf
+"
+" Use this command to get help on vim-qf:
+"
+"     :help qf
+"
+" If this doesn't work and you installed vim-qf manually, use the following
+" command to index vim-qf's documentation:
+"
+"     :helptags ~/.vim/doc
+"
+" or read your runtimepath/plugin manager documentation.
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! s:history(newer)
+    let loc = get(b:, 'qf_isLoc', 0)
+    let cmd = (loc ? 'l' : 'c') . (a:newer ? 'newer' : 'older')
+
+    try
+        execute cmd
+    catch /^Vim\%((\a\+)\)\=:E\%(380\|381\):/
+    endtry
+endfunction
+
+function! qf#history#Older()
+    call s:history(0)
+endfunction
+
+function! qf#history#Newer()
+    call s:history(1)
+endfunction
+
+let &cpo = s:save_cpo

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -96,6 +96,8 @@ Global mappings:
     <Plug>(qf_qf_toggle_stay) .................. |<Plug>(qf_qf_toggle_stay)|
     <Plug>(qf_loc_toggle) ...................... |<Plug>(qf_loc_toggle)|
     <Plug>(qf_loc_toggle_stay) ................. |<Plug>(qf_loc_toggle_stay)|
+    <Plug>(qf_older) ........................... |<Plug>(qf_older)|
+    <Plug>(qf_newer) ........................... |<Plug>(qf_newer)|
 
 Local mappings:
 
@@ -204,6 +206,19 @@ Uses |:lwindow| and |:lclose| under the hood.
 Example: >
 
     nmap <F6> <Plug>(qf_loc_toggle_stay)
+<
+------------------------------------------------------------------------------
+                                                             *<Plug>(qf_older)*
+                                                             *<Plug>(qf_newer)*
+Scope: local                                                                 ~
+Default: none                                                                ~
+
+In a location/quickfix window, navigate to an older or newer list.
+
+Example (in after/ftplugin/qf.vim): >
+
+    nmap <buffer> <Left>  <Plug>(qf_older)
+    nmap <buffer> <Right> <Plug>(qf_newer)
 <
 ------------------------------------------------------------------------------
                                                                *QfHistoryOlder*

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -43,6 +43,7 @@ These "local" features are only available in location/quickfix windows:
     - filter and restore the current list
     - perform commands on each line in the current list
     - perform commands on each file in the current list
+    - mappings to navigate between older and newer lists
     - jump to next group of entries belonging to same file ("file grouping")
     - save and load named lists
     - (optional) disable soft-wrapping
@@ -98,6 +99,8 @@ Global mappings:
 
 Local mappings:
 
+    <Left> ..................................... |QfHistoryOlder|
+    <Right> .................................... |QfHistoryNewer|
     { .......................................... |QfPreviousFile|
     } .......................................... |QfNextFile|
 
@@ -202,6 +205,14 @@ Example: >
 
     nmap <F6> <Plug>(qf_loc_toggle_stay)
 <
+------------------------------------------------------------------------------
+                                                               *QfHistoryOlder*
+                                                               *QfHistoryNewer*
+Scope: local                                                                 ~
+Default: <Left> and <Right>                                                  ~
+
+In a location/quickfix window, navigate to an older or newer list.
+
 ------------------------------------------------------------------------------
                                                                *QfPreviousFile*
                                                                    *QfNextFile*
@@ -559,6 +570,8 @@ a proper plugin come from Barry Arthur's Area 41 plugin:
 The named lists feature is the brainchild of Nelo-T. Wallus:
 
     - https://ntnn.de/
+
+The list history commands were implemented by Jon Parise.
 
 ==============================================================================
  7. TODO                                                              *qf-todo*

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -52,6 +52,10 @@ nnoremap <silent>        <Plug>(qf_loc_toggle_stay) :<C-u> call qf#toggle#Toggle
 " Jump to and from list
 nnoremap <silent> <expr> <Plug>(qf_qf_switch)       &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
 
+" Move forward and backward in list history (in a quickfix or location window)
+nnoremap <silent>        <Plug>(qf_older)           :<C-u> call qf#history#Older()<CR>
+nnoremap <silent>        <Plug>(qf_newer)           :<C-u> call qf#history#Newer()<CR>
+
 augroup qf
     autocmd!
 


### PR DESCRIPTION
This introduces local mappings (`<Left>` / `<Right>`) that navigate between
older and newer lists in the history.

Fixes #83