### PR TITLE
Implements #89, one shortcut to up/down on quickfix or location list

### DIFF
--- a/autoload/qf/wrap.vim
+++ b/autoload/qf/wrap.vim
@@ -46,4 +46,14 @@ function! qf#wrap#WrapCommand(direction, prefix)
     endif
 endfunction
 
+" Navigates in quick fix window to next/prev entry if quckfix is opened,
+" otherwise navigates up/down in location list.
+function! qf#wrap#WrapCommandQfOrLoc(direction)
+   if qf#IsQfWindowOpen()
+      call qf#wrap#WrapCommand(a:direction, 'c')
+   else
+      call qf#wrap#WrapCommand(a:direction, 'l')
+   endif
+endfunction
+
 let &cpo = s:save_cpo

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -91,6 +91,8 @@ Global mappings:
     <Plug>(qf_qf_next) ......................... |<Plug>(qf_qf_next)|
     <Plug>(qf_loc_previous) .................... |<Plug>(qf_loc_previous)|
     <Plug>(qf_loc_next) ........................ |<Plug>(qf_loc_next)|
+    <Plug>(qf_qf_or_loc_previous) .............. |<Plug>(qf_qf_or_loc_previous)|
+    <Plug>(qf_qf_or_loc_next) .................. |<Plug>(qf_qf_or_loc_next)|
     <Plug>(qf_qf_switch) ....................... |<Plug>(qf_qf_switch)|
     <Plug>(qf_qf_toggle) ....................... |<Plug>(qf_qf_toggle)|
     <Plug>(qf_qf_toggle_stay) .................. |<Plug>(qf_qf_toggle_stay)|

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -148,6 +148,20 @@ Example: >
     nmap <C-End>  <Plug>(qf_loc_next)
 <
 ------------------------------------------------------------------------------
+                                                *<Plug>(qf_qf_or_loc_previous)*
+                                                    *<Plug>(qf_qf_or_loc_next)*
+Scope: global                                                                ~
+Default: none                                                                ~
+
+Go up and down the quick quickfix list if one is opened. Othewise go up and
+down in the current location list. In both cases it makes wrap around.
+
+Example: >
+
+    nmap <S-Home> <Plug>(qf_qf_or_loc_previous)
+    nmap <S-End>  <Plug>(qf_qf_or_loc_next)
+
+------------------------------------------------------------------------------
                                                          *<Plug>(qf_qf_switch)*
 Scope: global                                                                ~
 Default: none                                                                ~

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -41,6 +41,11 @@ nnoremap <silent>        <Plug>(qf_qf_next)         :<C-u> call qf#wrap#WrapComm
 nnoremap <silent>        <Plug>(qf_loc_previous)    :<C-u> call qf#wrap#WrapCommand('up', 'l')<CR>
 nnoremap <silent>        <Plug>(qf_loc_next)        :<C-u> call qf#wrap#WrapCommand('down', 'l')<CR>
 
+
+" Go up and down quickfix or location list
+nnoremap <silent>        <Plug>(qf_qf_or_loc_previous)    :<C-u> call qf#wrap#WrapCommandQfOrLoc('up')<CR>
+nnoremap <silent>        <Plug>(qf_qf_or_loc_next)        :<C-u> call qf#wrap#WrapCommandQfOrLoc('down')<CR>
+
 " Toggle quickfix list
 nnoremap <silent>        <Plug>(qf_qf_toggle)       :<C-u> call qf#toggle#ToggleQfWindow(0)<CR>
 nnoremap <silent>        <Plug>(qf_qf_toggle_stay)  :<C-u> call qf#toggle#ToggleQfWindow(1)<CR>


### PR DESCRIPTION
I have no experience in writing VIM plugins, so perhaps there is something I did wrong.

This PR adds new commands <Plug>(qf_qf_or_loc_previous) or <Plug>(qf_qf_or_loc_next) to support the single couple of shortcuts for location list or quickfix. 
 