### PR TITLE
Add <Plug> mappings for the file grouping commands

### DIFF
--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -98,6 +98,8 @@ Global mappings:
     <Plug>(qf_loc_toggle_stay) ................. |<Plug>(qf_loc_toggle_stay)|
     <Plug>(qf_older) ........................... |<Plug>(qf_older)|
     <Plug>(qf_newer) ........................... |<Plug>(qf_newer)|
+    <Plug>(qf_previous_file) ................... |<Plug>(qf_previous_file)|
+    <Plug>(qf_next_file) ....................... |<Plug>(qf_next_file)|
 
 Local mappings:
 
@@ -219,6 +221,20 @@ Example (in after/ftplugin/qf.vim): >
 
     nmap <buffer> <Left>  <Plug>(qf_older)
     nmap <buffer> <Right> <Plug>(qf_newer)
+<
+------------------------------------------------------------------------------
+                                                     *<Plug>(qf_previous_file)*
+                                                         *<Plug>(qf_next_file)*
+Scope: local                                                                 ~
+Default: none                                                                ~
+
+In a location/quickfix window, jump to the next group of lines
+corresponding to a file.
+
+Example (in after/ftplugin/qf.vim): >
+
+    nmap <buffer> { <Plug>(qf_previous_file)
+    nmap <buffer> } <Plug>(qf_next_file)
 <
 ------------------------------------------------------------------------------
                                                                *QfHistoryOlder*

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -56,6 +56,10 @@ nnoremap <silent> <expr> <Plug>(qf_qf_switch)       &filetype ==# 'qf' ? '<C-w>p
 nnoremap <silent>        <Plug>(qf_older)           :<C-u> call qf#history#Older()<CR>
 nnoremap <silent>        <Plug>(qf_newer)           :<C-u> call qf#history#Newer()<CR>
 
+" Jump to previous and next file grouping (in a quickfix or location window)
+nnoremap <silent>        <Plug>(qf_previous_file)   :<C-u> call qf#filegroup#PreviousFile()<CR>
+nnoremap <silent>        <Plug>(qf_next_file)       :<C-u> call qf#filegroup#NextFile()<CR>
+
 augroup qf
     autocmd!
 


### PR DESCRIPTION
This introduces `<Plug>` mappings for the file-grouping commands. Yet another step towards removing the [hardcoded default mappings](https://github.com/romainl/vim-qf/blob/4a97465e8fd5f7d40748dd78fe315d1c41f4f4f8/after/ftplugin/qf.vim#L134-L141)...

Related: db2cfd06a9dc35d322870fd33740f63314a72f5e