### PR TITLE
Support count for <Plug>(qf_qf_previous) and friends

### DIFF
--- a/autoload/qf/wrap.vim
+++ b/autoload/qf/wrap.vim
@@ -24,17 +24,17 @@ set cpo&vim
 " TODO (romainl): Built-in :cn/:cp/:ln/:lp stop at the beginning
 "                 and end of the list. This allows us to wrap
 "                 around.
-function! qf#wrap#WrapCommand(direction, prefix)
+function! qf#wrap#WrapCommand(direction, prefix, count)
     if a:direction == "up"
         try
-            execute a:prefix . "previous"
+            execute a:count . a:prefix . "previous"
         catch /^Vim\%((\a\+)\)\=:E553/
             execute a:prefix . "last"
         catch /^Vim\%((\a\+)\)\=:E\%(325\|776\|42\):/
         endtry
     else
         try
-            execute a:prefix . "next"
+            execute a:count . a:prefix . "next"
         catch /^Vim\%((\a\+)\)\=:E553/
             execute a:prefix . "first"
         catch /^Vim\%((\a\+)\)\=:E\%(325\|776\|42\):/

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -34,12 +34,12 @@ nmap <silent>        <Plug>QfLtoggle   <Plug>(qf_loc_toggle)
 nmap <silent> <expr> <Plug>QfSwitch    &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
 
 " Go up and down quickfix list
-nnoremap <silent>        <Plug>(qf_qf_previous)     :<C-u> call qf#wrap#WrapCommand('up', 'c')<CR>
-nnoremap <silent>        <Plug>(qf_qf_next)         :<C-u> call qf#wrap#WrapCommand('down', 'c')<CR>
+nnoremap <silent>        <Plug>(qf_qf_previous)     :<C-u> call qf#wrap#WrapCommand('up', 'c', v:count1)<CR>
+nnoremap <silent>        <Plug>(qf_qf_next)         :<C-u> call qf#wrap#WrapCommand('down', 'c', v:count1)<CR>
 
 " Go up and down location list
-nnoremap <silent>        <Plug>(qf_loc_previous)    :<C-u> call qf#wrap#WrapCommand('up', 'l')<CR>
-nnoremap <silent>        <Plug>(qf_loc_next)        :<C-u> call qf#wrap#WrapCommand('down', 'l')<CR>
+nnoremap <silent>        <Plug>(qf_loc_previous)    :<C-u> call qf#wrap#WrapCommand('up', 'l', v:count1)<CR>
+nnoremap <silent>        <Plug>(qf_loc_next)        :<C-u> call qf#wrap#WrapCommand('down', 'l', v:count1)<CR>
 
 " Toggle quickfix list
 nnoremap <silent>        <Plug>(qf_qf_toggle)       :<C-u> call qf#toggle#ToggleQfWindow(0)<CR>


### PR DESCRIPTION
A count was ignored for <Plug>(qf_qf_previous), <Plug>(qf_qf_next), <Plug>(qf_loc_previous), and <Plug>(qf_loc_next). This is a rather simple implementation, and thus may not yet behave entirely as expected.

The count is only passed on to `:[cl]previous` and `:[cl]next`, but it is ignored when we wrap using `:[cl]first` and `:[cl]last`. So `100<Plug>(qf_qf_previous)` while at the top of the list will only jump to the end, not to the 100-to-last item in the list.

Also, `:[cl]previous` and `:[cl]next` do not throw when the count is greater than the number of items moved, e.g. `:3previous` while on the 2nd entry in the list will move to the 1st entry, so it doesn't wrap in that case.

I think both of these limitations are acceptable, but I'll gladly implement something a bit more complex to handle these cases. Wanted to check with you first, though, before doing unnecessary work.
