### PR TITLE
Silent lwindow error

### DIFF
--- a/autoload/qf/toggle.vim
+++ b/autoload/qf/toggle.vim
@@ -64,7 +64,7 @@ function! qf#toggle#ToggleLocWindow(stay) abort
             call winrestview(winview)
         endif
     else
-        lwindow
+        silent! lwindow
         if qf#IsLocWindowOpen(0)
             wincmd p
             if !empty(winview)


### PR DESCRIPTION
lwindow could throw E776 error, which I think should be suppressed when toggle loc window