### PR TITLE
Toggle the long/short path in current location/quikfix window

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -113,15 +113,22 @@ endfunction
 
 " open the quickfix window if there are valid errors
 function! qf#OpenQuickfix()
+    let a = getqflist({"all": 0})
+    let qf_list = a.items
+    if len(qf_list) == 0
+        return
+    endif
+
     if get(g:, 'qf_auto_open_quickfix', 1)
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
 
-        let qf_list = getqflist()
-
         " shorten paths if applicable
         if get(g:, 'qf_shorten_path', 1)
             call setqflist(qf#ShortenPathsInList(qf_list))
+            " add context to locate long/short list
+            call setqflist([], "a", {"id": a.id, "context": "vimqf_short_at_" . (a.id + 1)})
+            call setqflist([], "a", {"id": a.id+1, "context": "vimqf_long_at_" . a.id})
         endif
 
         execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(qf_list) ]) . 'cwindow' : 'cwindow'

--- a/autoload/qf/toggle.vim
+++ b/autoload/qf/toggle.vim
@@ -77,4 +77,29 @@ function! qf#toggle#ToggleLocWindow(stay) abort
     endif
 endfunction
 
+function! qf#toggle#ToggleShortenPath() abort
+    if qf#IsQfWindowOpen()
+        "let curlist = qf#GetList()
+        let cur = getqflist({"all": 0})
+        echom("current qf " . cur.id . " -- " . cur.context)
+
+        if len(cur.context) > 0 && type(cur.context) == type("")
+            let lt = split(cur.context, "_")
+            if lt[0] == "vimqf"
+                let flip_count = lt[-1] - cur.id
+                let cmd = flip_count > 0 ? "cnewer " . flip_count : "colder " . abs(flip_count)
+                execute cmd
+                echom(cmd)
+            endif
+        elseif cur.context == "" && get(g:, 'qf_shorten_path') == 0
+            call setqflist([], " ", {"nr": "$", 
+                                    \ "items": qf#ShortenPathsInList(cur.items), 
+                                    \ "context": "vimqf_long_at_" . cur.id})
+            let stack_size = getqflist({'nr' : '$'}).nr
+            echom("cur.id " . cur.id . " size " . stack_size)
+            call setqflist([], "a", {"id": cur.id, "context": "vimqf_short_at_" . stack_size})
+        endif
+    endif
+endfunction
+
 let &cpo = s:save_cpo

--- a/autoload/qf/toggle.vim
+++ b/autoload/qf/toggle.vim
@@ -77,27 +77,39 @@ function! qf#toggle#ToggleLocWindow(stay) abort
     endif
 endfunction
 
+function! s:flip(is_qf, cur_list)
+    let lt = split(a:cur_list.context, "_")
+    if lt[0] == "vimqf"
+        let flip_count = lt[-1] - a:cur_list.id
+        let cmd = (a:is_qf ? 'c' : 'l') . (flip_count > 0 ? ("newer " . flip_count) : ("older " . abs(flip_count)))
+        execute cmd
+    endif
+endfunction
+
+function! s:ctxarg(is_qf, is_long, cur_list)
+    let stack_size = a:is_qf ? getqflist({'nr' : '$'}).nr : getloclist(0, {'nr' : '$'}).nr
+    return a:is_long ? {"nr": "$",
+                        \ "items": qf#ShortenPathsInList(a:cur_list.items),
+                        \ "context": "vimqf_long_at_" . a:cur_list.id}
+                    \ : {"id": a:cur_list.id, "context": "vimqf_short_at_" . stack_size}
+endfunction
+
 function! qf#toggle#ToggleShortenPath() abort
     if qf#IsQfWindowOpen()
-        "let curlist = qf#GetList()
         let cur = getqflist({"all": 0})
-        echom("current qf " . cur.id . " -- " . cur.context)
-
         if len(cur.context) > 0 && type(cur.context) == type("")
-            let lt = split(cur.context, "_")
-            if lt[0] == "vimqf"
-                let flip_count = lt[-1] - cur.id
-                let cmd = flip_count > 0 ? "cnewer " . flip_count : "colder " . abs(flip_count)
-                execute cmd
-                echom(cmd)
-            endif
+            call s:flip(1, cur)
         elseif cur.context == "" && get(g:, 'qf_shorten_path') == 0
-            call setqflist([], " ", {"nr": "$", 
-                                    \ "items": qf#ShortenPathsInList(cur.items), 
-                                    \ "context": "vimqf_long_at_" . cur.id})
-            let stack_size = getqflist({'nr' : '$'}).nr
-            echom("cur.id " . cur.id . " size " . stack_size)
-            call setqflist([], "a", {"id": cur.id, "context": "vimqf_short_at_" . stack_size})
+            call setqflist([], " ", s:ctxarg(1, 1, cur))
+            call setqflist([], "a", s:ctxarg(1, 0, cur))
+        endif
+    elseif qf#IsLocWindowOpen(0)
+        let cur = getloclist(0, {"all": 0})
+        if len(cur.context) > 0 && type(cur.context) == type("")
+            call s:flip(0, cur)
+        elseif cur.context == "" && get(g:, 'qf_shorten_path') == 0
+            call setloclist(0, [], " ", s:ctxarg(0, 1, cur))
+            call setloclist(0, [], "a", s:ctxarg(0, 0, cur))
         endif
     endif
 endfunction

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -95,6 +95,7 @@ Global mappings:
     <Plug>(qf_qf_toggle) ....................... |<Plug>(qf_qf_toggle)|
     <Plug>(qf_qf_toggle_stay) .................. |<Plug>(qf_qf_toggle_stay)|
     <Plug>(qf_loc_toggle) ...................... |<Plug>(qf_loc_toggle)|
+    <Plug>(qf_shorten_path_toggle) ............. |<Plug>(qf_shorten_path_toggle)|
     <Plug>(qf_loc_toggle_stay) ................. |<Plug>(qf_loc_toggle_stay)|
     <Plug>(qf_older) ........................... |<Plug>(qf_older)|
     <Plug>(qf_newer) ........................... |<Plug>(qf_newer)|
@@ -196,6 +197,18 @@ Uses |:lwindow| and |:lclose| under the hood.
 Example: >
 
     nmap <F6> <Plug>(qf_loc_toggle)
+
+------------------------------------------------------------------------------
+                                                        *<Plug>(qf_shorten_path_toggle)*
+Scope: global                                                                ~
+Default: none                                                                ~
+
+Toggle the long/short path in current location/quikfix window.
+Only available when location/quickfix is open.
+
+Example: >
+
+    nmap <F7> <Plug>(qf_shorten_path_toggle)
 <
 ------------------------------------------------------------------------------
                                                    *<Plug>(qf_loc_toggle_stay)*

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -31,7 +31,6 @@ nmap <silent>        <Plug>QfLprevious <Plug>(qf_loc_previous)
 nmap <silent>        <Plug>QfLnext     <Plug>(qf_loc_next)
 nmap <silent>        <Plug>QfCtoggle   <Plug>(qf_qf_toggle)
 nmap <silent>        <Plug>QfLtoggle   <Plug>(qf_loc_toggle)
-nmap <silent>        <Plug>QfStoggle   <Plug>(qf_shorten_path_toggle)
 nmap <silent> <expr> <Plug>QfSwitch    &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
 
 " Go up and down quickfix list
@@ -52,7 +51,6 @@ nnoremap <silent>        <Plug>(qf_loc_toggle_stay) :<C-u> call qf#toggle#Toggle
 
 " Toggle shorten path
 nnoremap <silent>        <Plug>(qf_shorten_path_toggle)      :<C-u> call qf#toggle#ToggleShortenPath()<CR>
-
 
 " Jump to and from list
 nnoremap <silent> <expr> <Plug>(qf_qf_switch)       &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'

--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -31,6 +31,7 @@ nmap <silent>        <Plug>QfLprevious <Plug>(qf_loc_previous)
 nmap <silent>        <Plug>QfLnext     <Plug>(qf_loc_next)
 nmap <silent>        <Plug>QfCtoggle   <Plug>(qf_qf_toggle)
 nmap <silent>        <Plug>QfLtoggle   <Plug>(qf_loc_toggle)
+nmap <silent>        <Plug>QfStoggle   <Plug>(qf_shorten_path_toggle)
 nmap <silent> <expr> <Plug>QfSwitch    &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'
 
 " Go up and down quickfix list
@@ -48,6 +49,10 @@ nnoremap <silent>        <Plug>(qf_qf_toggle_stay)  :<C-u> call qf#toggle#Toggle
 " Toggle location list
 nnoremap <silent>        <Plug>(qf_loc_toggle)      :<C-u> call qf#toggle#ToggleLocWindow(0)<CR>
 nnoremap <silent>        <Plug>(qf_loc_toggle_stay) :<C-u> call qf#toggle#ToggleLocWindow(1)<CR>
+
+" Toggle shorten path
+nnoremap <silent>        <Plug>(qf_shorten_path_toggle)      :<C-u> call qf#toggle#ToggleShortenPath()<CR>
+
 
 " Jump to and from list
 nnoremap <silent> <expr> <Plug>(qf_qf_switch)       &filetype ==# 'qf' ? '<C-w>p' : '<C-w>b'


### PR DESCRIPTION
2e385e6

Toggle the long/short path in current location/quikfix window.
Only available when location/quickfix is open.

Example:
    `nmap <F7> <Plug>(qf_shorten_path_toggle)`