### PR TITLE
Resize with autocmd

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -140,6 +140,11 @@ nnoremap <silent> <buffer> <Right> :call qf#history#Newer()<CR>
 nnoremap <silent> <buffer> } :call qf#filegroup#NextFile()<CR>
 nnoremap <silent> <buffer> { :call qf#filegroup#PreviousFile()<CR>
 
+if get(g:, "qf_auto_resize", 1)
+    call qf#resize#Window()
+    autocmd qf TextChanged <buffer> call qf#resize#Window()
+endif
+
 " quit Vim if the last window is a quickfix window
 autocmd qf BufEnter    <buffer> nested if get(g:, 'qf_auto_quit', 1) | if winnr('$') < 2 | q | endif | endif
 autocmd qf BufWinEnter <buffer> nested if get(g:, 'qf_auto_quit', 1) | call qf#filter#ReuseTitle() | endif

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -95,12 +95,6 @@ function! qf#SetList(newlist, ...)
 
     " call partial with optional arguments
     call call(Func, a:000)
-
-    if get(b:, 'qf_isLoc', 0)
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
-    else
-        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
-    endif
 endfunction
 
 function! qf#GetEntryPath(line) abort
@@ -123,8 +117,6 @@ function! qf#OpenQuickfix()
         if get(g:, 'qf_shorten_path', 1)
             call setqflist(qf#ShortenPathsInList(qf_list))
         endif
-
-        execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(qf_list) ]) . 'cwindow' : 'cwindow'
     endif
 endfunction
 
@@ -140,8 +132,6 @@ function! qf#OpenLoclist()
         if get(g:, 'qf_shorten_path', 1)
             call setloclist(0, qf#ShortenPathsInList(loc_list))
         endif
-
-        execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(loc_list) ]) . 'lwindow' : 'lwindow'
     endif
 endfunction
 

--- a/autoload/qf/filter.vim
+++ b/autoload/qf/filter.vim
@@ -54,8 +54,6 @@ function! s:SetList(pat, reject, strategy)
             if a:strategy == 2
                 call setloclist(0, filter(getloclist(0), "v:val['text'] " . operator . " a:pat"), "r")
             endif
-
-            execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
         else
             " bufname && text
             if a:strategy == 0
@@ -71,8 +69,6 @@ function! s:SetList(pat, reject, strategy)
             if a:strategy == 2
                 call setqflist(filter(getqflist(), "v:val['text'] " . operator . " a:pat"), "r")
             endif
-
-            execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
         endif
     endif
 endfunction
@@ -225,7 +221,6 @@ function! qf#filter#RestoreList()
 
             if len(lists) > 0
                 call setloclist(0, getwinvar(winnr("#"), "qf_location_lists")[0], "r")
-                execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
 
                 call s:SetTitleValue(getwinvar(winnr("#"), "qf_location_titles")[0])
             else
@@ -235,7 +230,6 @@ function! qf#filter#RestoreList()
             if exists("g:qf_quickfix_lists")
                 if len(g:qf_quickfix_lists) > 0
                     call setqflist(g:qf_quickfix_lists[0], "r")
-                    execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(getqflist()) ]) . 'cwindow' : 'cwindow'
 
                     call s:SetTitleValue(g:qf_quickfix_titles[0])
                 else

--- a/autoload/qf/resize.vim
+++ b/autoload/qf/resize.vim
@@ -1,0 +1,27 @@
+" vim-qf - Tame the quickfix window
+" Maintainer:	romainl <romainlafourcade@gmail.com>
+" Version:	0.2.0
+" License:	MIT
+" Location:	autoload/resize.vim
+" Website:	https://github.com/romainl/vim-qf
+"
+" Use this command to get help on vim-qf:
+"
+"     :help qf
+"
+" If this doesn't work and you installed vim-qf manually, use the following
+" command to index vim-qf's documentation:
+"
+"     :helptags ~/.vim/doc
+"
+" or read your runtimepath/plugin manager documentation.
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! qf#resize#Window()
+    let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
+    execute "resize" min([ max_height, len(b:qf_isLoc ? getloclist(0) : getqflist()) ])
+endfunction
+
+let &cpo = s:save_cpo


### PR DESCRIPTION
This avoids repetition of some lengthy expressions. It also resizes the window rather than closing it and re-opening it with the specified height.