### PR TITLE
fix: startup errors in versions not supporting lambda shorthand in map()

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -147,7 +147,19 @@ endfunction
 
 " shorten file paths in given qf/loc list
 function! qf#ShortenPathsInList(list)
-    return map(a:list, {idx, entry -> extend(entry, {"module": pathshorten(bufname(entry["bufnr"]))})})
+  let index = 0
+  while index < len(a:list)
+    " item is a dict, sample: { lnum: 14, text: 'foo bar', bufnr: 3, ... }
+    let item = a:list[index]
+
+    let filepath = bufname(item["bufnr"])
+
+    " set the 'module' field to customise the visual filename in the qf/loc list (available since 8.0.1782)
+    let item["module"] = pathshorten(filepath)
+
+    let index = index + 1
+  endwhile
+  return a:list
 endfunction
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
**fix**: startup errors in versions not supporting lambda shorthand expressions in map() (versions prior to patch **7.4.2044**, _july 2016_)

**problem**: most versions prior to vim 8 (except the last ~3months of version 7.4.x) do not support the lambda shorthand expression which causes errors during startup. Also the one-liner was a bit hard to understand.

**solution**: refactor using a while loop instead with comments.