### PR TITLE
feat: use g:qf_shorten_path value to set pathshorten trim_len (Vim v8…

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -120,7 +120,7 @@ function! qf#OpenQuickfix()
         let qf_list = getqflist()
 
         " shorten paths if applicable
-        if get(g:, 'qf_shorten_path', 1)
+        if get(g:, 'qf_shorten_path', 0) > 0
             call setqflist(qf#ShortenPathsInList(qf_list))
         endif
 
@@ -137,7 +137,7 @@ function! qf#OpenLoclist()
         let loc_list = getloclist(0)
 
         " shorten paths if applicable
-        if get(g:, 'qf_shorten_path', 1)
+        if get(g:, 'qf_shorten_path', 0) > 0
             call setloclist(0, qf#ShortenPathsInList(loc_list))
         endif
 
@@ -153,9 +153,13 @@ function! qf#ShortenPathsInList(list)
     let item = a:list[index]
 
     let filepath = bufname(item["bufnr"])
+    let trim_len = get(g:, "qf_shorten_path", 1)
 
     " set the 'module' field to customise the visual filename in the qf/loc list (available since 8.0.1782)
-    let item["module"] = pathshorten(filepath)
+    if has('patch-8.2.1741')
+      let item["module"] = pathshorten(filepath, trim_len)
+    else
+      let item["module"] = pathshorten(filepath)
 
     let index = index + 1
   endwhile

--- a/doc/qf.txt
+++ b/doc/qf.txt
@@ -419,6 +419,10 @@ With the option set to `1` (vim-qf default):
 >
     v/l/p/w/l/o/s/filename.ext|87 col 22| …
 
+With the option set to `3` (Vim v8.2.1741 or above):
+>
+    ver/lon/pat/wit/lot/of/sub/filename.ext|87 col 22| …
+
 Add the line below to your vimrc to change the default value:
 >
     let g:qf_shorten_path = 0


### PR DESCRIPTION
feat: use g:qf_shorten_path value to set pathshorten trim_len (Vim v8.2.1741+)

problem: pathshorten by default is quite short to get a good sense of
what's going on. And disabling it altogether is perhaps too noisy.

solution: if has('patch-8.2.1741) supply the g:qf_shorten_path number
value as the newly added (Vim v8.2.1741) second param for pathshorten to
set the desired trimming length.