### PR TITLE
fix: missing endif after is+else block

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -160,6 +160,7 @@ function! qf#ShortenPathsInList(list)
       let item["module"] = pathshorten(filepath, trim_len)
     else
       let item["module"] = pathshorten(filepath)
+    endif
 
     let index = index + 1
   endwhile


### PR DESCRIPTION
problem: vim9 related (8.2.x+) updates throw error on missing endif and prevent plugin from loading properly resulting in infinite loops.

solution: add missing endif