### PR TITLE
Fix issue #76

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -38,7 +38,7 @@ else
 endif
 
 " are we in a location list or a quickfix list?
-let b:qf_isLoc = !empty(getloclist(0))
+let b:qf_isLoc = get(get(getwininfo(win_getid()), 0, {}), 'loclist', 0)
 
 " customize the statusline
 if exists("g:qf_statusline")

--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -96,6 +96,10 @@ function! qf#SetList(newlist, ...)
     " call partial with optional arguments
     call call(Func, a:000)
 
+    if a:newlist == []
+        return
+    endif
+
     if get(b:, 'qf_isLoc', 0)
         execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(getloclist(0)) ]) . 'lwindow' : 'lwindow'
     else


### PR DESCRIPTION
Improve the logic distinguishing the location list window from the
quickfix list window by inspecting the 'loclist' key in the output of
"getwininfo()".

When invoking "qf#SetList()" to clear the location list, bail out right
before ":lclose|lwindow".  Rationale: ":lwindow" will necessarily fail,
causing the subsequent invocation of "qf#SetList()" to unconditionally
use the quickfix list window.  We don't want that.  We want to stay in
the location list window if we're already in there.