### PR TITLE
Only check v:argv for -q if has patch-8.1.2233

### DIFF
--- a/plugin/qf.vim
+++ b/plugin/qf.vim
@@ -100,8 +100,12 @@ augroup qf
         " I can't make it work for :lhelpgrep
     endif
 
-    " spacial case for $ vim -q
-    autocmd VimEnter * nested if count(get(v:, 'argv', []), '-q') | call qf#OpenQuickfix() | endif
+    " special case for $ vim -q
+    if has('patch-8.1.2233')
+        autocmd VimEnter * nested if count(v:argv, '-q') | call qf#OpenQuickfix() | endif
+    else
+        autocmd VimEnter * nested call qf#OpenQuickfix()
+    endif
 
     " automatically close corresponding loclist when quitting a window
     if exists('##QuitPre')


### PR DESCRIPTION
Only check `v:argv` for `-q` flag is [patch 8.1.2233](https://github.com/manuelschiller/vim/commit/57cc59b59e0bf9b8142603d99189e270691b317e) is present. Otherwise, use behavior prior to https://github.com/romainl/vim-qf/commit/7f9bc496be3303f56c4426d1e63b9b47b64bdc5c.