### PR TITLE
Clear qf buffer autocmds before adding new ones

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -146,6 +146,7 @@ command! -buffer ListLists call qf#namedlist#ListLists()
 command! -buffer -nargs=* -bang -complete=customlist,qf#namedlist#CompleteList RemoveList call qf#namedlist#RemoveList(expand("<bang>") == "!" ? 1 : 0, <q-args>)
 
 " quit Vim if the last window is a quickfix window
+autocmd! qf * <buffer>
 autocmd qf BufEnter    <buffer> nested if get(g:, 'qf_auto_quit', 1) | if winnr('$') < 2 | q | endif | endif
 autocmd qf BufWinEnter <buffer> nested if get(g:, 'qf_auto_quit', 1) | call qf#filter#ReuseTitle() | endif
 


### PR DESCRIPTION
Currently, each time the quickfix window is opened, an extra `BufEnter` and `BufWinEnter` autocmd is added. This can be demonstrated (after opening the quickfix/locationlist windows a few times) with this command, which _should_ only output a single unique line for each buffer/event:

```vim
echo autocmd_get(#{group: 'qf', event: 'BufEnter'})->map({k,v->$'{v.event} {v.bufnr}: {v.cmd}'})->join("\n")
```

This change removes the buffer's existing autocmds before creating the new ones.