### PR TITLE
Fix `g:qf_shorten_path` behaviour

### DIFF
--- a/autoload/qf.vim
+++ b/autoload/qf.vim
@@ -121,13 +121,12 @@ function! qf#OpenQuickfix()
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
 
-        let qf_list_title = getqflist({ 'title': 1 })
+        let qf_list_title = getqflist({ 'title': 1 }).title
         let qf_list = getqflist()
 
         " shorten paths if applicable
-        if get(g:, 'qf_shorten_path', 0) > 0
-            call setqflist([], 'r', qf_list_title)
-            call setqflist(qf#ShortenPathsInList(qf_list), 'a')
+        if get(g:, 'qf_shorten_path', 1) > 0
+            call setqflist([], 'r', { 'title': qf_list_title, 'items': qf#ShortenPathsInList(qf_list) })
         endif
 
         execute get(g:, "qf_auto_resize", 1) ? 'cclose|' . min([ max_height, len(qf_list) ]) . 'cwindow' : 'cclose|cwindow'
@@ -140,13 +139,12 @@ function! qf#OpenLoclist()
         " get user-defined maximum height
         let max_height = get(g:, 'qf_max_height', 10) < 1 ? 10 : get(g:, 'qf_max_height', 10)
 
-        let loc_list_title = getloclist(0, { 'title': 1 })
+        let loc_list_title = getloclist(0, { 'title': 1 }).title
         let loc_list = getloclist(0)
 
         " shorten paths if applicable
-        if get(g:, 'qf_shorten_path', 0) > 0
-            call setloclist(0, [], 'r', loc_list_title)
-            call setloclist(0, qf#ShortenPathsInList(loc_list), 'a')
+        if get(g:, 'qf_shorten_path', 1) > 0
+            call setloclist(0, [], 'r', { 'title': loc_list_title, 'items': qf#ShortenPathsInList(loc_list) })
         endif
 
         execute get(g:, "qf_auto_resize", 1) ? 'lclose|' . min([ max_height, len(loc_list) ]) . 'lwindow' : 'lclose|lwindow'


### PR DESCRIPTION
The docs state that the default for `g:qf_shorten_path` is 1:

https://github.com/romainl/vim-qf/blob/7e65325651ff5a0b06af8df3980d2ee54cf10e14/doc/qf.txt#L396-L398

But this isn't the case as it was defaulted to `0` in qf.vim.

Additionally, I believe the intention of this call:

```
call setqflist([], 'r', qf_list_title)
```

is to clear the qflist whilst retaining the title. However, it doesn't actually clear the qflist because the first argument is ignored:

```
setqflist({list} [, {action} [, {what}]])               setqflist()
                Create or replace or add to the quickfix list.

                If the optional {what} dictionary argument is supplied, then
                only the items listed in {what} are set. The first {list}
                argument is ignored.  See below for the supported items in
                {what}.
```

This meant that when `g:qf_shorten_path` was set to > 0, the list with shortened paths was being appended to the list with full paths, resulting in duplicates.